### PR TITLE
correcting field for author email when both name and email are specified

### DIFF
--- a/ppsetuptools/ppsetuptools.py
+++ b/ppsetuptools/ppsetuptools.py
@@ -44,7 +44,7 @@ def _contributor_transform(contributors: List[Dict[str, str]]) -> Tuple[Optional
                 name = contributor.get('name')
                 email = contributor.get('email')
                 if name and email:
-                    contributor_names.append('{} <{}>'.format(name, email))
+                    contributor_emails.append('{} <{}>'.format(name, email))
                 elif name:
                     contributor_names.append(name)
                 elif email:

--- a/tests/ppsetuptools/test_ppsetuptools.py
+++ b/tests/ppsetuptools/test_ppsetuptools.py
@@ -120,8 +120,8 @@ def test_parse_kwargs() -> None:
         _HERE
     )
     assert result['long_description_content_type'] == test_file_content_type
-    assert result['author'] == test_toml_dict['authors'][0]['name'] + " <" + test_toml_dict['authors'][0]['email'] + ">"
-    assert result['maintainer'] == test_toml_dict['maintainers'][0]['name'] + \
+    assert result['author_email'] == test_toml_dict['authors'][0]['name'] + " <" + test_toml_dict['authors'][0]['email'] + ">"
+    assert result['maintainer_email'] == test_toml_dict['maintainers'][0]['name'] + \
         " <" + test_toml_dict['maintainers'][0]['email'] + ">"
 
 
@@ -133,8 +133,8 @@ def test_contributor_transform() -> None:
         }
     ]
     author, author_email = ppsetuptools._contributor_transform(authors)  # pylint: disable=protected-access
-    assert author == 'Me <me@me.com>'
-    assert author_email is None
+    assert author_email == 'Me <me@me.com>'
+    assert author is None
 
 
 def test_contributor_transform_no_name() -> None:


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0621/#authors-maintainers

> 3. If both email and name are provided, the value goes in Author-email/Maintainer-email as appropriate, with the format {name} <{email}> (with appropriate quoting, e.g. using email.headerregistry.Address).